### PR TITLE
Fix failing build and release workflow

### DIFF
--- a/.github/workflows/syrius_builder.yml
+++ b/.github/workflows/syrius_builder.yml
@@ -10,6 +10,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  FLUTTER_VERSION: "3.7.x"
+
 jobs:
   build-macos:
     runs-on: macos-12
@@ -25,6 +28,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{env.FLUTTER_VERSION}}
           channel: "stable"
       - name: Check flutter version
         run: flutter --version
@@ -60,6 +64,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{env.FLUTTER_VERSION}}
           channel: "stable"
       - name: Check flutter version
         run: flutter --version
@@ -87,6 +92,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: ${{env.FLUTTER_VERSION}}
           channel: "stable"
       - name: Check flutter version
         run: flutter --version


### PR DESCRIPTION
Closes #6 

The build and release workflow uses the latest Flutter SDK version that is available on the `stable` channel. The current codebase is not compatible with Flutter SDK versions `3.10.0` and newer, so the Flutter version must be constrained in the build and release workflow.

[Flutter SDK releases](https://docs.flutter.dev/release/archive) for reference.