### PR TITLE
Fix fuse button stays disabled

### DIFF
--- a/lib/widgets/modular_widgets/plasma_widgets/plasma_options/plasma_options.dart
+++ b/lib/widgets/modular_widgets/plasma_widgets/plasma_options/plasma_options.dart
@@ -132,6 +132,8 @@ class _PlasmaOptionsState extends State<PlasmaOptions> {
   void _beneficiaryAddressListener() {
     _beneficiaryAddressController.text =
         _plasmaBeneficiaryAddress!.getBeneficiaryAddress()!;
+    // Notify internal state has changed.
+    setState(() { });
   }
 
   Widget _getWidgetBody(AccountInfo? accountInfo) {


### PR DESCRIPTION
Closes #16 

When the beneficiary address changes the widget must notify that the internal state of the object has changed. The framework will schedule a [build] and the user interface for the subtree will be updated to reflect the new state.

See [setState](https://api.flutter.dev/flutter/widgets/State/setState.html) for more information.