### PR TITLE
Enable wakelock and disable auto-lock when swap is active

### DIFF
--- a/lib/handlers/htlc_swaps_handler.dart
+++ b/lib/handlers/htlc_swaps_handler.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:math';
 
+import 'package:collection/collection.dart';
 import 'package:logging/logging.dart';
 import 'package:wakelock/wakelock.dart';
 import 'package:zenon_syrius_wallet_flutter/blocs/auto_unlock_htlc_worker.dart';
@@ -30,8 +31,10 @@ class HtlcSwapsHandler {
     }
   }
 
-  bool get hasActiveSwaps => htlcSwapsService!
-      .getSwapsByState([P2pSwapState.pending, P2pSwapState.active]).isNotEmpty;
+  bool get hasActiveIncomingSwaps =>
+      htlcSwapsService!.getSwapsByState([P2pSwapState.active]).firstWhereOrNull(
+          (e) => e.direction == P2pSwapDirection.incoming) !=
+      null;
 
   Future<void> _runPeriodically() async {
     try {
@@ -61,7 +64,7 @@ class HtlcSwapsHandler {
   }
 
   Future<void> _enableWakelockIfNeeded() async {
-    if (!Platform.isLinux && hasActiveSwaps) {
+    if (!Platform.isLinux && hasActiveIncomingSwaps) {
       try {
         await Wakelock.enable();
       } catch (e) {

--- a/lib/handlers/htlc_swaps_handler.dart
+++ b/lib/handlers/htlc_swaps_handler.dart
@@ -36,9 +36,7 @@ class HtlcSwapsHandler {
   Future<void> _runPeriodically() async {
     try {
       _isRunning = true;
-      if (!Platform.isLinux && hasActiveSwaps) {
-        Wakelock.enable();
-      }
+      await _enableWakelockIfNeeded();
       if (!zenon!.wsClient.isClosed()) {
         final unresolvedSwaps = htlcSwapsService!.getSwapsByState([
           P2pSwapState.pending,
@@ -59,6 +57,17 @@ class HtlcSwapsHandler {
       Logger('HtlcSwapsHandler').log(Level.WARNING, '_runPeriodically', e);
     } finally {
       Future.delayed(const Duration(seconds: 5), () => _runPeriodically());
+    }
+  }
+
+  Future<void> _enableWakelockIfNeeded() async {
+    if (!Platform.isLinux && hasActiveSwaps) {
+      try {
+        await Wakelock.enable();
+      } catch (e) {
+        Logger('HtlcSwapsHandler')
+            .log(Level.WARNING, '_enableWakelockIfNeeded', e);
+      }
     }
   }
 

--- a/lib/handlers/htlc_swaps_handler.dart
+++ b/lib/handlers/htlc_swaps_handler.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:math';
 
 import 'package:logging/logging.dart';
+import 'package:wakelock/wakelock.dart';
 import 'package:zenon_syrius_wallet_flutter/blocs/auto_unlock_htlc_worker.dart';
 import 'package:zenon_syrius_wallet_flutter/main.dart';
 import 'package:zenon_syrius_wallet_flutter/model/block_data.dart';
@@ -28,9 +30,15 @@ class HtlcSwapsHandler {
     }
   }
 
+  bool get hasActiveSwaps => htlcSwapsService!
+      .getSwapsByState([P2pSwapState.pending, P2pSwapState.active]).isNotEmpty;
+
   Future<void> _runPeriodically() async {
     try {
       _isRunning = true;
+      if (!Platform.isLinux && hasActiveSwaps) {
+        Wakelock.enable();
+      }
       if (!zenon!.wsClient.isClosed()) {
         final unresolvedSwaps = htlcSwapsService!.getSwapsByState([
           P2pSwapState.pending,

--- a/lib/widgets/main_app_container.dart
+++ b/lib/widgets/main_app_container.dart
@@ -626,7 +626,7 @@ class _MainAppContainerState extends State<MainAppContainer>
 
   Timer _createAutoLockTimer() {
     return Timer.periodic(Duration(minutes: kAutoLockWalletMinutes!), (timer) {
-      if (!sl<HtlcSwapsHandler>().hasActiveSwaps) {
+      if (!sl<HtlcSwapsHandler>().hasActiveIncomingSwaps) {
         _lockBloc.addEvent(LockEvent.navigateToLock);
       }
     });

--- a/lib/widgets/main_app_container.dart
+++ b/lib/widgets/main_app_container.dart
@@ -625,10 +625,7 @@ class _MainAppContainerState extends State<MainAppContainer>
   }
 
   Timer _createAutoLockTimer() {
-    return Timer.periodic(
-        Duration(
-          minutes: kAutoLockWalletMinutes!,
-        ), (timer) {
+    return Timer.periodic(Duration(minutes: kAutoLockWalletMinutes!), (timer) {
       if (!sl<HtlcSwapsHandler>().hasActiveSwaps) {
         _lockBloc.addEvent(LockEvent.navigateToLock);
       }

--- a/lib/widgets/main_app_container.dart
+++ b/lib/widgets/main_app_container.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_vector_icons/flutter_vector_icons.dart';
 import 'package:provider/provider.dart';
 import 'package:zenon_syrius_wallet_flutter/blocs/blocs.dart';
+import 'package:zenon_syrius_wallet_flutter/handlers/htlc_swaps_handler.dart';
 import 'package:zenon_syrius_wallet_flutter/main.dart';
 import 'package:zenon_syrius_wallet_flutter/model/model.dart';
 import 'package:zenon_syrius_wallet_flutter/utils/app_colors.dart';
@@ -460,10 +461,7 @@ class _MainAppContainerState extends State<MainAppContainer>
   }
 
   Future<void> _mainLockCallback(String password) async {
-    _navigateToLockTimer = Timer.periodic(
-      Duration(minutes: kAutoLockWalletMinutes!),
-      (timer) => _lockBloc.addEvent(LockEvent.navigateToLock),
-    );
+    _navigateToLockTimer = _createAutoLockTimer();
     _lockBloc.addEvent(LockEvent.navigateToPreviousTab);
   }
 
@@ -492,12 +490,7 @@ class _MainAppContainerState extends State<MainAppContainer>
   }
 
   void _afterAppInitCallback() {
-    _navigateToLockTimer = Timer.periodic(
-      Duration(
-        minutes: kAutoLockWalletMinutes!,
-      ),
-      (timer) => _lockBloc.addEvent(LockEvent.navigateToLock),
-    );
+    _navigateToLockTimer = _createAutoLockTimer();
     _lockBloc.addEvent(LockEvent.navigateToDashboard);
     _listenToAutoReceiveTxWorkerNotifications();
   }
@@ -597,10 +590,7 @@ class _MainAppContainerState extends State<MainAppContainer>
       switch (event) {
         case LockEvent.countDown:
           if (kCurrentPage != Tabs.lock) {
-            _navigateToLockTimer = Timer.periodic(
-              Duration(minutes: kAutoLockWalletMinutes!),
-              (timer) => _lockBloc.addEvent(LockEvent.navigateToLock),
-            );
+            _navigateToLockTimer = _createAutoLockTimer();
           }
           break;
         case LockEvent.navigateToDashboard:
@@ -621,10 +611,7 @@ class _MainAppContainerState extends State<MainAppContainer>
         case LockEvent.resetTimer:
           if (_navigateToLockTimer != null && _navigateToLockTimer!.isActive) {
             _navigateToLockTimer?.cancel();
-            _navigateToLockTimer = Timer.periodic(
-              Duration(minutes: kAutoLockWalletMinutes!),
-              (timer) => _lockBloc.addEvent(LockEvent.navigateToLock),
-            );
+            _navigateToLockTimer = _createAutoLockTimer();
           }
           break;
         case LockEvent.navigateToPreviousTab:
@@ -635,5 +622,16 @@ class _MainAppContainerState extends State<MainAppContainer>
     if (widget.redirectedFromWalletSuccess) {
       _lockBloc.addEvent(LockEvent.countDown);
     }
+  }
+
+  Timer _createAutoLockTimer() {
+    return Timer.periodic(
+        Duration(
+          minutes: kAutoLockWalletMinutes!,
+        ), (timer) {
+      if (!sl<HtlcSwapsHandler>().hasActiveSwaps) {
+        _lockBloc.addEvent(LockEvent.navigateToLock);
+      }
+    });
   }
 }

--- a/lib/widgets/modular_widgets/p2p_swap_widgets/htlc_card.dart
+++ b/lib/widgets/modular_widgets/p2p_swap_widgets/htlc_card.dart
@@ -140,8 +140,6 @@ class _HtlcCardState extends State<HtlcCard>
       height: 94.0,
       child: LoadingInfoText(
         text: 'Waiting for the counterparty to join the swap.',
-        tooltipText:
-            'Your wallet will not be auto-locked while the swap is in progress.',
       ),
     );
   }

--- a/lib/widgets/modular_widgets/p2p_swap_widgets/htlc_card.dart
+++ b/lib/widgets/modular_widgets/p2p_swap_widgets/htlc_card.dart
@@ -140,6 +140,8 @@ class _HtlcCardState extends State<HtlcCard>
       height: 94.0,
       child: LoadingInfoText(
         text: 'Waiting for the counterparty to join the swap.',
+        tooltipText:
+            'Your wallet will not be auto-locked while the swap is in progress.',
       ),
     );
   }

--- a/lib/widgets/modular_widgets/p2p_swap_widgets/modals/native_p2p_swap_modal.dart
+++ b/lib/widgets/modular_widgets/p2p_swap_widgets/modals/native_p2p_swap_modal.dart
@@ -423,8 +423,11 @@ class _NativeP2pSwapModalState extends State<NativeP2pSwapModal> {
             child: const Padding(
               padding: EdgeInsets.symmetric(vertical: 15.0),
               child: LoadingInfoText(
-                  text:
-                      'Waiting for the counterparty. Please keep Syrius running.'),
+                text:
+                    'Waiting for the counterparty. Please keep Syrius running.',
+                tooltipText:
+                    'Your wallet will not be auto-locked while the swap is in progress.',
+              ),
             ),
           ),
         ],

--- a/lib/widgets/reusable_widgets/loading_info_text.dart
+++ b/lib/widgets/reusable_widgets/loading_info_text.dart
@@ -4,9 +4,11 @@ import 'package:zenon_syrius_wallet_flutter/widgets/reusable_widgets/loading_wid
 
 class LoadingInfoText extends StatelessWidget {
   final String text;
+  final String? tooltipText;
 
   const LoadingInfoText({
     required this.text,
+    this.tooltipText,
     Key? key,
   }) : super(key: key);
 
@@ -26,7 +28,27 @@ class LoadingInfoText extends StatelessWidget {
           text,
           style:
               const TextStyle(fontSize: 14.0, color: AppColors.subtitleColor),
-        )
+        ),
+        Visibility(
+          visible: tooltipText != null,
+          child: const SizedBox(
+            width: 5.0,
+          ),
+        ),
+        Visibility(
+          visible: tooltipText != null,
+          child: Tooltip(
+            message: tooltipText ?? '',
+            child: const Padding(
+              padding: EdgeInsets.only(top: 1.0),
+              child: Icon(
+                Icons.help,
+                color: AppColors.subtitleColor,
+                size: 14.0,
+              ),
+            ),
+          ),
+        ),
       ],
     );
   }


### PR DESCRIPTION
The purpose of this PR is to ensure that the host machine does not go into sleep mode and that Syrius' keystore stays unlocked when Syrius is left running for extended periods of time while participating in an incoming P2P swap. It is important that Syrius can actively monitor the chain for the preimage in this situation.

The wakelock is enabled when there are active incoming P2P swaps. The wakelock attempts to keep the host machine from going into sleep mode. The wakelock is not supported on Linux.

It is also important that the keystore stays unlocked while an incoming swap is being conducted, since Syrius has to automatically send the transaction to complete the swap safely. The user is informed via a tooltip that Syrius will not auto-lock when the swap is in progress.