### PR TITLE
Adjust P2P swap expiration times

### DIFF
--- a/lib/widgets/modular_widgets/p2p_swap_widgets/htlc_card.dart
+++ b/lib/widgets/modular_widgets/p2p_swap_widgets/htlc_card.dart
@@ -105,7 +105,7 @@ class _HtlcCardState extends State<HtlcCard>
     with SingleTickerProviderStateMixin {
   late final AnimationController _animationController;
 
-  final Duration _expirationWarningThreshold = const Duration(minutes: 60);
+  final Duration _expirationWarningThreshold = const Duration(minutes: 30);
   final Duration _animationDuration = const Duration(milliseconds: 100);
   final Cubic _animationCurve = Curves.easeInOut;
 

--- a/lib/widgets/modular_widgets/p2p_swap_widgets/modals/join_native_swap_modal.dart
+++ b/lib/widgets/modular_widgets/p2p_swap_widgets/modals/join_native_swap_modal.dart
@@ -400,7 +400,7 @@ class _JoinNativeSwapModalState extends State<JoinNativeSwapModal> {
 
   int? _calculateSafeExpirationTime(int initialHtlcExpiration) {
     const minimumSafeTime = Duration(hours: 1);
-    const maxExpirationTime = Duration(days: 1);
+    const maxExpirationTime = Duration(hours: 1);
     final now = DateTimeUtils.unixTimeNow;
     final remaining = Duration(seconds: initialHtlcExpiration - now);
     final safeTime = remaining ~/ 2;

--- a/lib/widgets/modular_widgets/p2p_swap_widgets/modals/start_native_swap_modal.dart
+++ b/lib/widgets/modular_widgets/p2p_swap_widgets/modals/start_native_swap_modal.dart
@@ -49,7 +49,7 @@ class _StartNativeSwapModalState extends State<StartNativeSwapModal> {
   late BasicDropdownItem<int> _selectedLockDuration;
 
   final List<BasicDropdownItem<int>> _lockDurationItems = [
-    BasicDropdownItem(label: '3 hours', value: kOneHourInSeconds * 3),
+    BasicDropdownItem(label: '6 hours', value: kOneHourInSeconds * 6),
     BasicDropdownItem(label: '12 hours', value: kOneHourInSeconds * 12),
     BasicDropdownItem(label: '24 hours', value: kOneHourInSeconds * 24),
   ];


### PR DESCRIPTION
The purpose of these changes is to improve the safety of the swap for the joining party. By setting the maximum expiration time to 1 hour for the swap's counter HTLC, the time window that the joining party has to stay vigilant is greatly reduced. With this change, the joining party has to stay vigilant about the swap for a maximum of only 1 hour.

The minimum expiration time for the swap's starting party has been increased to 6 hours. This is meant to give the joining party more time to unlock the initial HTLC, improving the swap's safety. The swap's starting party basically has no risk of losing funds, so they will have to carry the burden of having their funds locked for a longer period of time in case the swap is unsuccessful.