### PR TITLE
Add hash back to auto-receive tx queue on all exceptions

### DIFF
--- a/lib/blocs/auto_receive_tx_worker.dart
+++ b/lib/blocs/auto_receive_tx_worker.dart
@@ -58,6 +58,11 @@ class AutoReceiveTxWorker extends BaseBloc<WalletNotification> {
         } else {
           _sendErrorNotification(e.toString());
         }
+      } catch (e, stackTrace) {
+        Logger('AutoReceiveTxWorker')
+            .log(Level.WARNING, 'autoReceive', e, stackTrace);
+        pool.addFirst(currentHash);
+        _sendErrorNotification(e.toString());
       }
       running = false;
     }


### PR DESCRIPTION
This is an attempt to fix #4.

In case an exception is thrown by the auto-receiver, the tx hash is added back into the queue so that it is retried.