### PR TITLE
Improve P2P swap expiration times configuration

### DIFF
--- a/lib/blocs/p2p_swap/htlc_swap/complete_htlc_swap_bloc.dart
+++ b/lib/blocs/p2p_swap/htlc_swap/complete_htlc_swap_bloc.dart
@@ -6,8 +6,6 @@ import 'package:zenon_syrius_wallet_flutter/utils/utils.dart';
 import 'package:znn_sdk_dart/znn_sdk_dart.dart';
 
 class CompleteHtlcSwapBloc extends BaseBloc<HtlcSwap?> {
-  final safeExpirationThreshold = const Duration(minutes: 10);
-
   Future<void> completeHtlcSwap({
     required HtlcSwap swap,
   }) async {
@@ -21,7 +19,7 @@ class CompleteHtlcSwapBloc extends BaseBloc<HtlcSwap?> {
       // until expiration.
       final htlc = await zenon!.embedded.htlc.getById(Hash.parse(htlcId));
       if (htlc.expirationTime <=
-          DateTimeUtils.unixTimeNow + safeExpirationThreshold.inSeconds) {
+          DateTimeUtils.unixTimeNow + kMinSafeTimeToCompleteSwap.inSeconds) {
         throw 'The swap will expire too soon for a safe swap.';
       }
 

--- a/lib/handlers/htlc_swaps_handler.dart
+++ b/lib/handlers/htlc_swaps_handler.dart
@@ -110,7 +110,7 @@ class HtlcSwapsHandler {
     }
 
     try {
-      return AccountBlockUtils.getAccountBlocksAfterTime(
+      return await AccountBlockUtils.getAccountBlocksAfterTime(
           htlcAddress, max(oldestSwapStartTime, lastCheckedBlockTime));
     } catch (e, stackTrace) {
       Logger('HtlcSwapsHandler')

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -225,3 +225,11 @@ const List<Tabs> kTabsWithIconTitles = [
 const List<Tabs> kDisabledTabs = [
   Tabs.resyncWallet,
 ];
+
+// P2P swap constants
+const Duration kInitialHtlcDuration = Duration(hours: 8);
+const Duration kCounterHtlcDuration = Duration(minutes: 30);
+const Duration kMaxAllowedInitialHtlcDuration = Duration(hours: 24);
+const Duration kMinSafeTimeToFindPreimage = Duration(hours: 7);
+const Duration kMinSafeTimeToCompleteSwap = Duration(minutes: 10);
+const Duration kHtlcExpirationWarningThreshold = Duration(minutes: 20);

--- a/lib/widgets/modular_widgets/p2p_swap_widgets/htlc_card.dart
+++ b/lib/widgets/modular_widgets/p2p_swap_widgets/htlc_card.dart
@@ -105,7 +105,6 @@ class _HtlcCardState extends State<HtlcCard>
     with SingleTickerProviderStateMixin {
   late final AnimationController _animationController;
 
-  final Duration _expirationWarningThreshold = const Duration(minutes: 30);
   final Duration _animationDuration = const Duration(milliseconds: 100);
   final Cubic _animationCurve = Curves.easeInOut;
 
@@ -202,7 +201,8 @@ class _HtlcCardState extends State<HtlcCard>
     final remaining =
         Duration(seconds: expirationTime - DateTimeUtils.unixTimeNow);
     return Visibility(
-      visible: !remaining.isNegative && remaining < _expirationWarningThreshold,
+      visible:
+          !remaining.isNegative && remaining < kHtlcExpirationWarningThreshold,
       child: Row(
         children: [
           const Icon(

--- a/lib/widgets/modular_widgets/p2p_swap_widgets/modals/start_native_swap_modal.dart
+++ b/lib/widgets/modular_widgets/p2p_swap_widgets/modals/start_native_swap_modal.dart
@@ -3,7 +3,6 @@ import 'package:stacked/stacked.dart';
 import 'package:zenon_syrius_wallet_flutter/blocs/dashboard/balance_bloc.dart';
 import 'package:zenon_syrius_wallet_flutter/blocs/p2p_swap/htlc_swap/start_htlc_swap_bloc.dart';
 import 'package:zenon_syrius_wallet_flutter/main.dart';
-import 'package:zenon_syrius_wallet_flutter/model/basic_dropdown_item.dart';
 import 'package:zenon_syrius_wallet_flutter/model/p2p_swap/htlc_swap.dart';
 import 'package:zenon_syrius_wallet_flutter/model/p2p_swap/p2p_swap.dart';
 import 'package:zenon_syrius_wallet_flutter/utils/app_colors.dart';
@@ -16,7 +15,6 @@ import 'package:zenon_syrius_wallet_flutter/utils/zts_utils.dart';
 import 'package:zenon_syrius_wallet_flutter/widgets/reusable_widgets/bullet_point_card.dart';
 import 'package:zenon_syrius_wallet_flutter/widgets/reusable_widgets/buttons/instruction_button.dart';
 import 'package:zenon_syrius_wallet_flutter/widgets/reusable_widgets/dropdown/addresses_dropdown.dart';
-import 'package:zenon_syrius_wallet_flutter/widgets/reusable_widgets/dropdown/basic_dropdown.dart';
 import 'package:zenon_syrius_wallet_flutter/widgets/reusable_widgets/error_widget.dart';
 import 'package:zenon_syrius_wallet_flutter/widgets/reusable_widgets/input_fields/amount_input_field.dart';
 import 'package:zenon_syrius_wallet_flutter/widgets/reusable_widgets/input_fields/input_field.dart';
@@ -46,21 +44,12 @@ class _StartNativeSwapModalState extends State<StartNativeSwapModal> {
       TextEditingController();
   final TextEditingController _amountController = TextEditingController();
 
-  late BasicDropdownItem<int> _selectedLockDuration;
-
-  final List<BasicDropdownItem<int>> _lockDurationItems = [
-    BasicDropdownItem(label: '6 hours', value: kOneHourInSeconds * 6),
-    BasicDropdownItem(label: '12 hours', value: kOneHourInSeconds * 12),
-    BasicDropdownItem(label: '24 hours', value: kOneHourInSeconds * 24),
-  ];
-
   bool _isLoading = false;
 
   @override
   void initState() {
     super.initState();
     sl.get<BalanceBloc>().getBalanceForAllAddresses();
-    _selectedLockDuration = _lockDurationItems[1];
   }
 
   @override
@@ -180,24 +169,6 @@ class _StartNativeSwapModalState extends State<StartNativeSwapModal> {
             ),
           ),
         ),
-        kVerticalSpacing,
-        LabeledInputContainer(
-          labelText: 'Your deposit expires in',
-          helpText:
-              'If the swap is unsuccessful you can reclaim your funds after the deposit has expired.',
-          inputWidget: BasicDropdown<int>(
-            'Lock duration',
-            _selectedLockDuration,
-            _lockDurationItems,
-            (duration) => setState(
-              () {
-                if (duration != null) {
-                  _selectedLockDuration = duration;
-                }
-              },
-            ),
-          ),
-        ),
         const SizedBox(height: 20.0),
         BulletPointCard(
           bulletPoints: [
@@ -207,7 +178,16 @@ class _StartNativeSwapModalState extends State<StartNativeSwapModal> {
             ),
             RichText(
               text: BulletPointCard.textSpan(
-                  'You can reclaim your funds if the counterparty fails to join the swap.'),
+                '''You can reclaim your funds in ''',
+                children: [
+                  TextSpan(
+                      text: '${kInitialHtlcDuration.inHours} hours',
+                      style:
+                          const TextStyle(fontSize: 14.0, color: Colors.white)),
+                  BulletPointCard.textSpan(
+                      ' if the counterparty fails to join the swap.'),
+                ],
+              ),
             ),
             RichText(
               text: BulletPointCard.textSpan(
@@ -267,7 +247,7 @@ class _StartNativeSwapModalState extends State<StartNativeSwapModal> {
         swapType: P2pSwapType.native,
         fromChain: P2pSwapChain.nom,
         toChain: P2pSwapChain.nom,
-        initialHtlcDuration: _selectedLockDuration.value);
+        initialHtlcDuration: kInitialHtlcDuration.inSeconds);
   }
 
   bool _isInputValid() =>


### PR DESCRIPTION
The various duration constants regarding P2P swaps have been moved to the global constants file.

The expiration times/durations for HTLCs have also been modified as follows:

* The initial HTLC's duration is now always 8 hours. The user cannot select a duration anymore.

* The counter HTLC's duration is now always 30 minutes.

* The joining party must join the swap within 30 minutes of the creation of the initial HTLC. This ensures the joining party or an HTLC watchtower has at least 7 hours to find the preimage, since the initial HTLC's duration is 8 hours.

The reason for these changes is to improve the swap safety for the joining party by further reducing the time the joining party has to stay vigilant during the swap (now only 30 minutes).

Having a short counter HTLC duration essentially means that both parties have to be online to conduct the swap in a short span of time. Because of this, I don't see a reason to offer the user the option to select a duration for the initial HTLC. The swap shouldn't be started if both parties can't be online for the duration of the swap.


