### PR TITLE
Call setState when updating the swap completed text

### DIFF
--- a/lib/widgets/modular_widgets/p2p_swap_widgets/modals/native_p2p_swap_modal.dart
+++ b/lib/widgets/modular_widgets/p2p_swap_widgets/modals/native_p2p_swap_modal.dart
@@ -441,8 +441,10 @@ class _NativeP2pSwapModalState extends State<NativeP2pSwapModal> {
         model.stream.listen(
           (event) async {
             if (event is HtlcSwap) {
-              _swapCompletedText =
-                  'Swap completed. You will receive the funds shortly.';
+              setState(() {
+                _swapCompletedText =
+                    'Swap completed. You will receive the funds shortly.';
+              });
             }
           },
           onError: (error) {


### PR DESCRIPTION
Call `setState` when the swap completed text is updated to make sure changes are reflected.