### PR TITLE
Prevent the same hash from being added twice into the auto receive tx pool

### DIFF
--- a/lib/blocs/auto_receive_tx_worker.dart
+++ b/lib/blocs/auto_receive_tx_worker.dart
@@ -91,6 +91,8 @@ class AutoReceiveTxWorker extends BaseBloc<WalletNotification> {
   Future<void> addHash(Hash hash) async {
     if (!pool.contains(hash)) {
       zenon!.stats.syncInfo().then((syncInfo) {
+        // Verify that the pool does not already contain the hash after the
+        // asynchronous request has completed and that the node is in sync.
         if (!pool.contains(hash) &&
             (syncInfo.state == SyncState.syncDone ||
                 (syncInfo.targetHeight > 0 &&

--- a/lib/blocs/auto_receive_tx_worker.dart
+++ b/lib/blocs/auto_receive_tx_worker.dart
@@ -91,10 +91,11 @@ class AutoReceiveTxWorker extends BaseBloc<WalletNotification> {
   Future<void> addHash(Hash hash) async {
     if (!pool.contains(hash)) {
       zenon!.stats.syncInfo().then((syncInfo) {
-        if ((syncInfo.state == SyncState.syncDone ||
-            (syncInfo.targetHeight > 0 &&
-                syncInfo.currentHeight > 0 &&
-                (syncInfo.targetHeight - syncInfo.currentHeight) < 3))) {
+        if (!pool.contains(hash) &&
+            (syncInfo.state == SyncState.syncDone ||
+                (syncInfo.targetHeight > 0 &&
+                    syncInfo.currentHeight > 0 &&
+                    (syncInfo.targetHeight - syncInfo.currentHeight) < 3))) {
           pool.add(hash);
         }
       });


### PR DESCRIPTION
Since the `addHash` function contains asynchronous code, it is possible to add the same hash into the pool more than once, if the function is called in short succession.

This fix checks that the hash is not in the pool after the asynchronous code has run.