### PR TITLE
Verify the uniqueness of the hashlock when joining a swap

### DIFF
--- a/lib/blocs/p2p_swap/htlc_swap/initial_htlc_for_swap_bloc.dart
+++ b/lib/blocs/p2p_swap/htlc_swap/initial_htlc_for_swap_bloc.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:collection/collection.dart';
 import 'package:zenon_syrius_wallet_flutter/blocs/base_bloc.dart';
 import 'package:zenon_syrius_wallet_flutter/main.dart';
 import 'package:zenon_syrius_wallet_flutter/utils/utils.dart';
@@ -11,6 +12,7 @@ class InitialHtlcForSwapBloc extends BaseBloc<HtlcInfo?> {
   Future<void> getInitialHtlc(Hash id) async {
     try {
       final htlc = await zenon!.embedded.htlc.getById(id);
+      final hashlock = FormatUtils.encodeHexString(htlc.hashLock);
       if (!kDefaultAddressList.contains(htlc.hashLocked.toString())) {
         throw 'This deposit is not intended for you.';
       }
@@ -20,9 +22,7 @@ class InitialHtlcForSwapBloc extends BaseBloc<HtlcInfo?> {
       if (htlcSwapsService!.getSwapByHtlcId(htlc.id.toString()) != null) {
         throw 'This deposit is already used in another swap.';
       }
-      if (htlcSwapsService!
-              .getSwapByHashLock(FormatUtils.encodeHexString(htlc.hashLock)) !=
-          null) {
+      if (htlcSwapsService!.getSwapByHashLock(hashlock) != null) {
         throw 'The deposit\'s hashlock is already used in another swap.';
       }
       final remainingDuration =
@@ -42,9 +42,47 @@ class InitialHtlcForSwapBloc extends BaseBloc<HtlcInfo?> {
           kMaxAllowedInitialHtlcDuration.inSeconds) {
         throw 'The deposit was created too long ago.';
       }
+
+      // Verify that the hashlock has not been used in another currently active
+      // HTLC.
+      final htlcBlocks = await AccountBlockUtils.getAccountBlocksAfterTime(
+          htlcAddress,
+          htlc.expirationTime - kMaxAllowedInitialHtlcDuration.inSeconds);
+      if (htlcBlocks.firstWhereOrNull((block) =>
+              !_isInitialHtlcBlock(block, htlc.id) &&
+              _hasMatchingHashlock(block, hashlock)) !=
+          null) {
+        throw 'The hashlock is not unique.';
+      }
       addEvent(htlc);
     } catch (e, stackTrace) {
       addError(e, stackTrace);
     }
   }
+}
+
+bool _isInitialHtlcBlock(AccountBlock block, Hash initialHtlcId) {
+  if (block.blockType != BlockTypeEnum.contractReceive.index) {
+    return false;
+  }
+  return block.pairedAccountBlock!.hash == initialHtlcId;
+}
+
+bool _hasMatchingHashlock(AccountBlock block, String hashlock) {
+  if (block.blockType != BlockTypeEnum.contractReceive.index) {
+    return false;
+  }
+
+  final blockData = AccountBlockUtils.getDecodedBlockData(
+      Definitions.htlc, block.pairedAccountBlock!.data);
+
+  if (blockData == null || blockData.function != 'Create') {
+    return false;
+  }
+
+  if (!blockData.params.containsKey('hashLock')) {
+    return false;
+  }
+
+  return FormatUtils.encodeHexString(blockData.params['hashLock']) == hashlock;
 }

--- a/lib/widgets/modular_widgets/p2p_swap_widgets/modals/join_native_swap_modal.dart
+++ b/lib/widgets/modular_widgets/p2p_swap_widgets/modals/join_native_swap_modal.dart
@@ -205,6 +205,7 @@ class _JoinNativeSwapModalState extends State<JoinNativeSwapModal> {
   void _onContinueButtonPressed(InitialHtlcForSwapBloc model) async {
     setState(() {
       _isLoading = true;
+      _initialHtlcError = null;
     });
     model.getInitialHtlc(Hash.parse(_depositIdController.text));
   }


### PR DESCRIPTION
The purpose of this addition is to make sure that when joining a swap the hashlock of the initial HTLC has not been used in the past 24 hours (`kMaxAllowedInitialHtlcDuration`). This is done because the HTLC watchtower will only monitor one HTLC with a given hashlock (this is to mitigate an attack vector against the watchtower).

The implementation fetches all the HTLCs created in the 24 hours (`kMaxAllowedInitialHtlcDuration`) preceding the expiration time of the initial HTLC and verifies that the initial HTLC's hashlock is unique before allowing the user to join the swap.