### PR TITLE
Add option for deleting P2P swap history

### DIFF
--- a/lib/services/htlc_swaps_service.dart
+++ b/lib/services/htlc_swaps_service.dart
@@ -88,6 +88,15 @@ class HtlcSwapsService {
   Future<void> deleteSwap(String swapId) async =>
       await _htlcSwapsBox!.delete(swapId);
 
+  Future<void> deleteInactiveSwaps() async =>
+      await _htlcSwapsBox!.deleteAll(_swapsForCurrentChainId
+          .where((e) => [
+                P2pSwapState.completed,
+                P2pSwapState.unsuccessful,
+                P2pSwapState.error
+              ].contains(e.state))
+          .map((e) => e.id));
+
   List<HtlcSwap> get _swapsForCurrentChainId {
     return kNodeChainId != null
         ? _htlcSwapsBox!.values

--- a/lib/widgets/modular_widgets/p2p_swap_widgets/p2p_swaps_card.dart
+++ b/lib/widgets/modular_widgets/p2p_swap_widgets/p2p_swaps_card.dart
@@ -52,15 +52,41 @@ class _P2pSwapsCardState extends State<P2pSwapsCard> {
   @override
   Widget build(BuildContext context) {
     return CardScaffold<List<P2pSwap>>(
-        title: 'P2P Swaps',
-        childStream: _p2pSwapsListBloc.stream,
-        onCompletedStatusCallback: (data) => data.isEmpty
-            ? const SyriusErrorWidget('No P2P swaps')
-            : _getTable(data),
-        onRefreshPressed: () => _p2pSwapsListBloc.getData(),
-        description:
-            'This card displays a list of P2P swaps that have been conducted '
-            'with this wallet.');
+      title: 'P2P Swaps',
+      childStream: _p2pSwapsListBloc.stream,
+      onCompletedStatusCallback: (data) => data.isEmpty
+          ? const SyriusErrorWidget('No P2P swaps')
+          : _getTable(data),
+      onRefreshPressed: () => _p2pSwapsListBloc.getData(),
+      description:
+          'This card displays a list of P2P swaps that have been conducted '
+          'with this wallet.',
+      customItem: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          onTap: _onDeleteSwapHistoryTapped,
+          child: Row(
+            children: [
+              const Icon(
+                Icons.delete,
+                color: AppColors.znnColor,
+                size: 20.0,
+              ),
+              const SizedBox(
+                width: 5.0,
+                height: 38.0,
+              ),
+              Expanded(
+                child: Text(
+                  'Delete swap history',
+                  style: Theme.of(context).textTheme.bodyLarge,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 
   void _onSwapTapped(String swapId) {
@@ -80,10 +106,22 @@ class _P2pSwapsCardState extends State<P2pSwapsCard> {
         description:
             'Are you sure you want to delete this swap? This action cannot be undone.',
         onYesButtonPressed: () async {
-          Navigator.of(context).pop();
           if (swap.mode == P2pSwapMode.htlc) {
             await htlcSwapsService!.deleteSwap(swap.id);
           }
+          _p2pSwapsListBloc.getData();
+        });
+  }
+
+  Future<void> _onDeleteSwapHistoryTapped() async {
+    showDialogWithNoAndYesOptions(
+        context: context,
+        isBarrierDismissible: true,
+        title: 'Delete swap history',
+        description:
+            'Are you sure you want to delete your swap history? Active swaps cannot be deleted.',
+        onYesButtonPressed: () async {
+          await htlcSwapsService!.deleteInactiveSwaps();
           _p2pSwapsListBloc.getData();
         });
   }

--- a/lib/widgets/reusable_widgets/layout_scaffold/card_scaffold.dart
+++ b/lib/widgets/reusable_widgets/layout_scaffold/card_scaffold.dart
@@ -21,6 +21,7 @@ class CardScaffold<T> extends StatefulWidget {
   final Widget Function(T)? onCompletedStatusCallback;
   final double? titleFontSize;
   final Widget? titleIcon;
+  final Widget? customItem;
 
   const CardScaffold({
     required this.title,
@@ -31,6 +32,7 @@ class CardScaffold<T> extends StatefulWidget {
     this.onCompletedStatusCallback,
     this.titleFontSize,
     this.titleIcon,
+    this.customItem,
     Key? key,
   }) : super(key: key);
 
@@ -212,6 +214,7 @@ class _CardScaffoldState<T> extends State<CardScaffold<T>> {
               ],
             ),
           ),
+          if (widget.customItem != null) widget.customItem!
         ],
       ),
     );


### PR DESCRIPTION
This PR adds an option to the P2P Swaps card for deleting the swap history. Active swaps cannot be deleted since swaps cannot be restored once deleted.