### PR TITLE
Add width constraints to shown amounts and token symbols

### DIFF
--- a/lib/widgets/modular_widgets/p2p_swap_widgets/htlc_card.dart
+++ b/lib/widgets/modular_widgets/p2p_swap_widgets/htlc_card.dart
@@ -170,9 +170,25 @@ class _HtlcCardState extends State<HtlcCard>
             children: [
               Row(
                 children: [
-                  Text(
-                    '${widget.amount!.addDecimals(widget.tokenDecimals!)} ${widget.tokenSymbol!}',
-                    style: const TextStyle(fontSize: 18.0),
+                  Container(
+                    constraints: const BoxConstraints(maxWidth: 280),
+                    child: Text(
+                      widget.amount!.addDecimals(widget.tokenDecimals!),
+                      style: const TextStyle(fontSize: 18.0),
+                      overflow: TextOverflow.ellipsis,
+                      maxLines: 1,
+                      softWrap: false,
+                    ),
+                  ),
+                  Container(
+                    constraints: const BoxConstraints(maxWidth: 150),
+                    child: Text(
+                      ' ${widget.tokenSymbol!}',
+                      style: const TextStyle(fontSize: 18.0),
+                      overflow: TextOverflow.ellipsis,
+                      maxLines: 1,
+                      softWrap: false,
+                    ),
                   ),
                   const SizedBox(
                     width: 8.0,

--- a/lib/widgets/modular_widgets/p2p_swap_widgets/modals/native_p2p_swap_modal.dart
+++ b/lib/widgets/modular_widgets/p2p_swap_widgets/modals/native_p2p_swap_modal.dart
@@ -100,10 +100,9 @@ class _NativeP2pSwapModalState extends State<NativeP2pSwapModal> {
   }
 
   Widget _getPendingView() {
-    return SizedBox(
+    return const SizedBox(
       height: 215.0,
-      child:
-          Column(mainAxisAlignment: MainAxisAlignment.center, children: const [
+      child: Column(mainAxisAlignment: MainAxisAlignment.center, children: [
         Text(
           'Starting swap. This will take a moment.',
           style: TextStyle(
@@ -181,13 +180,14 @@ class _NativeP2pSwapModalState extends State<NativeP2pSwapModal> {
                 Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
-                    const Text('From',
-                        style: TextStyle(
-                            fontSize: 14.0, color: AppColors.subtitleColor)),
-                    Text(
-                        '${swap.fromAmount.addDecimals(swap.fromDecimals)} ${swap.fromSymbol}',
-                        style: const TextStyle(
-                            fontSize: 14.0, color: AppColors.subtitleColor)),
+                    const Text(
+                      'From',
+                      style: TextStyle(
+                          fontSize: 14.0, color: AppColors.subtitleColor),
+                    ),
+                    _getAmountAndSymbolWidget(
+                        swap.fromAmount.addDecimals(swap.fromDecimals),
+                        swap.fromSymbol),
                   ],
                 ),
                 const SizedBox(
@@ -196,13 +196,14 @@ class _NativeP2pSwapModalState extends State<NativeP2pSwapModal> {
                 Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
-                    const Text('To',
-                        style: TextStyle(
-                            fontSize: 14.0, color: AppColors.subtitleColor)),
-                    Text(
-                        '${swap.toAmount!.addDecimals(swap.toDecimals!)} ${swap.toSymbol!}',
-                        style: const TextStyle(
-                            fontSize: 14.0, color: AppColors.subtitleColor)),
+                    const Text(
+                      'To',
+                      style: TextStyle(
+                          fontSize: 14.0, color: AppColors.subtitleColor),
+                    ),
+                    _getAmountAndSymbolWidget(
+                        swap.toAmount!.addDecimals(swap.toDecimals!),
+                        swap.toSymbol!),
                   ],
                 ),
                 const SizedBox(
@@ -311,16 +312,15 @@ class _NativeP2pSwapModalState extends State<NativeP2pSwapModal> {
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     Text(
-                        swap.state == P2pSwapState.reclaimable
-                            ? 'Deposited amount'
-                            : 'Deposited amount (reclaimed)',
-                        style: const TextStyle(
-                            fontSize: 14.0, color: AppColors.subtitleColor)),
-                    Text(
-                      '${swap.fromAmount.addDecimals(swap.fromDecimals)} ${swap.fromSymbol}',
+                      swap.state == P2pSwapState.reclaimable
+                          ? 'Deposited amount'
+                          : 'Deposited amount (reclaimed)',
                       style: const TextStyle(
                           fontSize: 14.0, color: AppColors.subtitleColor),
                     ),
+                    _getAmountAndSymbolWidget(
+                        swap.fromAmount.addDecimals(swap.fromDecimals),
+                        swap.fromSymbol),
                   ],
                 ),
               ],
@@ -554,5 +554,34 @@ class _NativeP2pSwapModalState extends State<NativeP2pSwapModal> {
         toAmount: swap.toAmount!,
         toDecimals: swap.toDecimals!,
         toSymbol: swap.toSymbol!);
+  }
+
+  Widget _getAmountAndSymbolWidget(String amount, String symbol) {
+    return Row(
+      children: [
+        Container(
+          constraints: const BoxConstraints(maxWidth: 150),
+          child: Text(
+            amount,
+            style:
+                const TextStyle(fontSize: 14.0, color: AppColors.subtitleColor),
+            overflow: TextOverflow.ellipsis,
+            maxLines: 1,
+            softWrap: false,
+          ),
+        ),
+        Container(
+          constraints: const BoxConstraints(maxWidth: 100),
+          child: Text(
+            ' $symbol',
+            style:
+                const TextStyle(fontSize: 14.0, color: AppColors.subtitleColor),
+            overflow: TextOverflow.ellipsis,
+            maxLines: 1,
+            softWrap: false,
+          ),
+        ),
+      ],
+    );
   }
 }

--- a/lib/widgets/modular_widgets/p2p_swap_widgets/p2p_swaps_list_item.dart
+++ b/lib/widgets/modular_widgets/p2p_swap_widgets/p2p_swaps_list_item.dart
@@ -148,7 +148,7 @@ class _P2pSwapsListItemState extends State<P2pSwapsListItem> {
         Row(
           children: [
             Container(
-              constraints: const BoxConstraints(maxWidth: 100),
+              constraints: const BoxConstraints(maxWidth: 70),
               child: _getTextWidget(amount.addDecimals(decimals)),
             ),
             Container(

--- a/lib/widgets/modular_widgets/p2p_swap_widgets/p2p_swaps_list_item.dart
+++ b/lib/widgets/modular_widgets/p2p_swap_widgets/p2p_swaps_list_item.dart
@@ -127,11 +127,12 @@ class _P2pSwapsListItemState extends State<P2pSwapsListItem> {
   }
 
   Widget _getTextWidget(String text) {
-    return Text(
-      text,
-      style: const TextStyle(
-          fontSize: 12.0, height: 1, color: AppColors.subtitleColor),
-    );
+    return Text(text,
+        style: const TextStyle(
+            fontSize: 12.0, height: 1, color: AppColors.subtitleColor),
+        overflow: TextOverflow.ellipsis,
+        maxLines: 1,
+        softWrap: false);
   }
 
   Widget _getAmountWidget(
@@ -144,7 +145,18 @@ class _P2pSwapsListItemState extends State<P2pSwapsListItem> {
     }
     return Row(
       children: [
-        _getTextWidget('${amount.addDecimals(decimals)} $symbol'),
+        Row(
+          children: [
+            Container(
+              constraints: const BoxConstraints(maxWidth: 100),
+              child: _getTextWidget(amount.addDecimals(decimals)),
+            ),
+            Container(
+              constraints: const BoxConstraints(maxWidth: 50),
+              child: _getTextWidget(' $symbol'),
+            ),
+          ],
+        ),
         const SizedBox(
           width: 6.0,
         ),


### PR DESCRIPTION
 This PR fixes the text overflow issues that were highlighted [here](https://github.com/hypercore-one/syrius/pull/36#issuecomment-1665031583). Only the widgets related to P2P Swaps are in the scope of this PR.