### PR TITLE
Add deposit recovery feature

### DIFF
--- a/lib/blocs/p2p_swap/htlc_swap/recover_htlc_swap_funds_bloc.dart
+++ b/lib/blocs/p2p_swap/htlc_swap/recover_htlc_swap_funds_bloc.dart
@@ -1,0 +1,27 @@
+import 'package:zenon_syrius_wallet_flutter/blocs/p2p_swap/htlc_swap/reclaim_htlc_swap_funds_bloc.dart';
+import 'package:zenon_syrius_wallet_flutter/main.dart';
+import 'package:zenon_syrius_wallet_flutter/utils/constants.dart';
+import 'package:zenon_syrius_wallet_flutter/utils/date_time_utils.dart';
+import 'package:zenon_syrius_wallet_flutter/utils/format_utils.dart';
+import 'package:zenon_syrius_wallet_flutter/utils/global.dart';
+import 'package:znn_sdk_dart/znn_sdk_dart.dart';
+
+class RecoverHtlcSwapFundsBloc extends ReclaimHtlcSwapFundsBloc {
+  void recoverFunds({required Hash htlcId}) async {
+    try {
+      final htlc = await zenon!.embedded.htlc.getById(htlcId);
+
+      if (!kDefaultAddressList.contains(htlc.timeLocked.toString())) {
+        throw 'The deposit does not belong to you.';
+      }
+
+      if (htlc.expirationTime - DateTimeUtils.unixTimeNow > 0) {
+        throw 'The deposit is locked until ${FormatUtils.formatDate(htlc.expirationTime * 1000, dateFormat: kDefaultDateTimeFormat)}.';
+      }
+
+      reclaimFunds(htlcId: htlcId, selfAddress: htlc.timeLocked);
+    } catch (e, stackTrace) {
+      addError(e, stackTrace);
+    }
+  }
+}

--- a/lib/widgets/modular_widgets/p2p_swap_widgets/modals/recover_deposit_modal.dart
+++ b/lib/widgets/modular_widgets/p2p_swap_widgets/modals/recover_deposit_modal.dart
@@ -1,0 +1,231 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:stacked/stacked.dart';
+import 'package:zenon_syrius_wallet_flutter/blocs/dashboard/balance_bloc.dart';
+import 'package:zenon_syrius_wallet_flutter/blocs/p2p_swap/htlc_swap/recover_htlc_swap_funds_bloc.dart';
+import 'package:zenon_syrius_wallet_flutter/main.dart';
+import 'package:zenon_syrius_wallet_flutter/utils/app_colors.dart';
+import 'package:zenon_syrius_wallet_flutter/utils/clipboard_utils.dart';
+import 'package:zenon_syrius_wallet_flutter/utils/input_validators.dart';
+import 'package:zenon_syrius_wallet_flutter/utils/toast_utils.dart';
+import 'package:zenon_syrius_wallet_flutter/widgets/reusable_widgets/buttons/instruction_button.dart';
+import 'package:zenon_syrius_wallet_flutter/widgets/reusable_widgets/important_text_container.dart';
+import 'package:zenon_syrius_wallet_flutter/widgets/reusable_widgets/input_fields/input_fields.dart';
+import 'package:zenon_syrius_wallet_flutter/widgets/reusable_widgets/modals/base_modal.dart';
+import 'package:znn_sdk_dart/znn_sdk_dart.dart';
+
+class RecoverDepositModal extends StatefulWidget {
+  const RecoverDepositModal({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  State<RecoverDepositModal> createState() => _RecoverDepositModalState();
+}
+
+class _RecoverDepositModalState extends State<RecoverDepositModal> {
+  final TextEditingController _depositIdController = TextEditingController();
+
+  String? _errorText;
+
+  bool _isLoading = false;
+  bool _isPendingFunds = false;
+
+  @override
+  void initState() {
+    super.initState();
+    sl.get<BalanceBloc>().getBalanceForAllAddresses();
+  }
+
+  @override
+  void dispose() {
+    _depositIdController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseModal(
+      title: _getTitle(),
+      child: _getContent(),
+    );
+  }
+
+  String _getTitle() {
+    return _isPendingFunds ? '' : 'Recover deposit';
+  }
+
+  Widget _getContent() {
+    return _isPendingFunds ? _getPendingFundsView() : _getSearchView();
+  }
+
+  Widget _getPendingFundsView() {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        const SizedBox(
+          height: 10.0,
+        ),
+        Container(
+          width: 72.0,
+          height: 72.0,
+          color: Colors.transparent,
+          child: SvgPicture.asset(
+            'assets/svg/ic_completed_symbol.svg',
+            colorFilter:
+                const ColorFilter.mode(AppColors.znnColor, BlendMode.srcIn),
+          ),
+        ),
+        const SizedBox(
+          height: 30.0,
+        ),
+        const Text(
+          'Recovery transaction sent. You will receive the funds shortly.',
+          style: TextStyle(
+            fontSize: 16.0,
+          ),
+        ),
+        const SizedBox(
+          height: 30.0,
+        ),
+      ],
+    );
+  }
+
+  Widget _getSearchView() {
+    return Column(
+      children: [
+        const SizedBox(
+          height: 20.0,
+        ),
+        const Text(
+          'If you have lost access to the machine that a swap was started on, the deposited funds can be recovered with the deposit ID.\n\nIf you don\'t have the deposit ID, please refer to the swap tutorial for instructions on how to recover it using a block explorer.',
+          style: TextStyle(
+            fontSize: 14.0,
+          ),
+        ),
+        const SizedBox(
+          height: 20.0,
+        ),
+        MouseRegion(
+          cursor: SystemMouseCursors.click,
+          child: GestureDetector(
+            child: const Row(
+              children: [
+                Text(
+                  'View swap tutorial',
+                  style: TextStyle(
+                    color: AppColors.subtitleColor,
+                    fontSize: 14.0,
+                  ),
+                ),
+                SizedBox(
+                  width: 3.0,
+                ),
+                Icon(
+                  Icons.open_in_new,
+                  size: 18.0,
+                  color: AppColors.subtitleColor,
+                ),
+              ],
+            ),
+            // TODO: Open link to tutorial
+            onTap: () => ToastUtils.showToast(context, 'No tutorial yet'),
+          ),
+        ),
+        const SizedBox(
+          height: 25.0,
+        ),
+        Form(
+          autovalidateMode: AutovalidateMode.onUserInteraction,
+          child: InputField(
+            onChanged: (value) {
+              setState(() {});
+            },
+            validator: (value) => InputValidators.checkHash(value),
+            controller: _depositIdController,
+            suffixIcon: RawMaterialButton(
+              shape: const CircleBorder(),
+              onPressed: () => ClipboardUtils.pasteToClipboard(
+                context,
+                (String value) {
+                  _depositIdController.text = value;
+                  setState(() {});
+                },
+              ),
+              child: const Icon(
+                Icons.content_paste,
+                color: AppColors.darkHintTextColor,
+                size: 15.0,
+              ),
+            ),
+            suffixIconConstraints: const BoxConstraints(
+              maxWidth: 45.0,
+              maxHeight: 20.0,
+            ),
+            hintText: 'Deposit ID',
+            contentLeftPadding: 10.0,
+          ),
+        ),
+        const SizedBox(
+          height: 25.0,
+        ),
+        Visibility(
+          visible: _errorText != null,
+          child: Column(
+            children: [
+              ImportantTextContainer(
+                text: _errorText ?? '',
+                showBorder: true,
+              ),
+              const SizedBox(
+                height: 20.0,
+              ),
+            ],
+          ),
+        ),
+        _getRecoverButton(),
+      ],
+    );
+  }
+
+  Widget _getRecoverButton() {
+    return ViewModelBuilder<RecoverHtlcSwapFundsBloc>.reactive(
+      onViewModelReady: (model) {
+        model.stream.listen(
+          (event) async {
+            if (event is AccountBlockTemplate) {
+              setState(() {
+                _isPendingFunds = true;
+              });
+            }
+          },
+          onError: (error) {
+            setState(() {
+              _errorText = error.toString();
+              _isLoading = false;
+            });
+          },
+        );
+      },
+      builder: (_, model, __) => InstructionButton(
+        text: 'Recover deposit',
+        isEnabled: _isHashValid(),
+        isLoading: _isLoading,
+        loadingText: 'Sending transaction',
+        instructionText: 'Input the deposit ID',
+        onPressed: () {
+          setState(() {
+            _isLoading = true;
+            _errorText = null;
+          });
+          model.recoverFunds(htlcId: Hash.parse(_depositIdController.text));
+        },
+      ),
+      viewModelBuilder: () => RecoverHtlcSwapFundsBloc(),
+    );
+  }
+
+  bool _isHashValid() =>
+      InputValidators.checkHash(_depositIdController.text) == null;
+}

--- a/lib/widgets/modular_widgets/p2p_swap_widgets/p2p_swap_options_card.dart
+++ b/lib/widgets/modular_widgets/p2p_swap_widgets/p2p_swap_options_card.dart
@@ -7,6 +7,7 @@ import 'package:zenon_syrius_wallet_flutter/utils/app_colors.dart';
 import 'package:zenon_syrius_wallet_flutter/utils/toast_utils.dart';
 import 'package:zenon_syrius_wallet_flutter/widgets/modular_widgets/p2p_swap_widgets/modals/join_native_swap_modal.dart';
 import 'package:zenon_syrius_wallet_flutter/widgets/modular_widgets/p2p_swap_widgets/modals/native_p2p_swap_modal.dart';
+import 'package:zenon_syrius_wallet_flutter/widgets/modular_widgets/p2p_swap_widgets/modals/recover_deposit_modal.dart';
 import 'package:zenon_syrius_wallet_flutter/widgets/modular_widgets/p2p_swap_widgets/modals/start_native_swap_modal.dart';
 import 'package:zenon_syrius_wallet_flutter/widgets/modular_widgets/p2p_swap_widgets/p2p_swap_options_button.dart';
 import 'package:zenon_syrius_wallet_flutter/widgets/reusable_widgets/dialogs.dart';
@@ -36,6 +37,36 @@ class _P2pSwapOptionsCardState extends State<P2pSwapOptionsCard> {
       title: 'P2P Swap Options',
       description: 'Starting and joining P2P swaps can be done from this card.',
       childBuilder: () => _getWidgetBody(context),
+      customItem: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          onTap: () {
+            showCustomDialog(
+              context: context,
+              content: const RecoverDepositModal(),
+            );
+          },
+          child: Row(
+            children: [
+              const Icon(
+                Icons.refresh,
+                color: AppColors.znnColor,
+                size: 20.0,
+              ),
+              const SizedBox(
+                width: 5.0,
+                height: 38.0,
+              ),
+              Expanded(
+                child: Text(
+                  'Recover deposit',
+                  style: Theme.of(context).textTheme.bodyLarge,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 

--- a/lib/widgets/reusable_widgets/layout_scaffold/card_scaffold.dart
+++ b/lib/widgets/reusable_widgets/layout_scaffold/card_scaffold.dart
@@ -21,6 +21,7 @@ class CardScaffold<T> extends StatefulWidget {
   final Widget Function(T)? onCompletedStatusCallback;
   final double? titleFontSize;
   final Widget? titleIcon;
+  final Widget? customItem;
 
   const CardScaffold({
     required this.title,
@@ -31,6 +32,7 @@ class CardScaffold<T> extends StatefulWidget {
     this.onCompletedStatusCallback,
     this.titleFontSize,
     this.titleIcon,
+    this.customItem,
     Key? key,
   }) : super(key: key);
 
@@ -212,6 +214,7 @@ class _CardScaffoldState<T> extends State<CardScaffold<T>> {
               ],
             ),
           ),
+          if (widget.customItem != null) widget.customItem!
         ],
       ),
     );


### PR DESCRIPTION
This PR adds the option to recover (=reclaim) any HTLC deposit that the user has created.

The motivation behind this feature is that in a situation where the user has lost access to the machine on which they have ongoing swaps on, there has to be a way for the user to recover the funds on a separate machine.  There is no mechanism built in that can restore swap items on a separate machine/instance of Syrius.

The user needs their deposit's ID to recover the funds. If the user does not have the deposit ID, the user is instructed to see the swap tutorial for instructions on how to find the deposit ID via an explorer.

The deposit recovery feature is intentionally kept minimalistic, since it should be a relatively rare edge case where the user completely loses access to their machine while they have ongoing swaps.

Screenshot of the deposit recovery modal that is opened from the P2P Swap Options card's menu:
![image](https://github.com/hypercore-one/syrius/assets/90819192/29c98780-fbb8-44b6-ba8d-09dfeca1dc1b)
