### PR TITLE
Add P2P swap warning modal

### DIFF
--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -225,3 +225,5 @@ const Duration kMaxAllowedInitialHtlcDuration = Duration(hours: 24);
 const Duration kMinSafeTimeToFindPreimage = Duration(hours: 7);
 const Duration kMinSafeTimeToCompleteSwap = Duration(minutes: 10);
 const Duration kHtlcExpirationWarningThreshold = Duration(minutes: 20);
+const String kHasReadP2pSwapWarningKey = 'has_read_p2p_swap_warning';
+const bool kHasReadP2pSwapWarningDefaultValue = false;

--- a/lib/widgets/modular_widgets/p2p_swap_widgets/modals/p2p_swap_warning_modal.dart
+++ b/lib/widgets/modular_widgets/p2p_swap_widgets/modals/p2p_swap_warning_modal.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:zenon_syrius_wallet_flutter/widgets/reusable_widgets/modals/base_modal.dart';
+
+class P2PSwapWarningModal extends StatefulWidget {
+  final Function() onAccepted;
+
+  const P2PSwapWarningModal({
+    required this.onAccepted,
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  State<P2PSwapWarningModal> createState() => _P2PSwapWarningModalState();
+}
+
+class _P2PSwapWarningModalState extends State<P2PSwapWarningModal> {
+  @override
+  Widget build(BuildContext context) {
+    return BaseModal(
+      title: 'Before continuing',
+      child: _getContent(),
+    );
+  }
+
+  Widget _getContent() {
+    return Column(
+      children: [
+        const SizedBox(
+          height: 20.0,
+        ),
+        const Text(
+          '''Please note that the P2P swap is an experimental feature and may result in funds being lost.\n\n'''
+          '''Use the feature with caution and consider splitting large swaps into multiple smaller ones.''',
+          style: TextStyle(
+            fontSize: 14.0,
+          ),
+        ),
+        const SizedBox(
+          height: 30.0,
+        ),
+        SizedBox(
+          width: double.infinity,
+          child: ElevatedButton(
+            onPressed: () => widget.onAccepted.call(),
+            child: Text(
+              'Continue',
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/reusable_widgets/important_text_container.dart
+++ b/lib/widgets/reusable_widgets/important_text_container.dart
@@ -1,87 +1,53 @@
 import 'package:flutter/material.dart';
 import 'package:zenon_syrius_wallet_flutter/utils/app_colors.dart';
 
-class ImportantTextContainer extends StatefulWidget {
+class ImportantTextContainer extends StatelessWidget {
   final String text;
   final bool showBorder;
-  final bool animateBorder;
   final bool isSelectable;
 
   const ImportantTextContainer({
     required this.text,
     this.showBorder = false,
-    this.animateBorder = false,
     this.isSelectable = false,
     Key? key,
   }) : super(key: key);
 
   @override
-  State<ImportantTextContainer> createState() => _ImportantTextContainerState();
-}
-
-class _ImportantTextContainerState extends State<ImportantTextContainer>
-    with TickerProviderStateMixin {
-  double _animationValue = 8.0;
-
-  @override
   Widget build(BuildContext context) {
-    return TweenAnimationBuilder<double>(
-      duration: const Duration(milliseconds: 2500),
-      tween: Tween(begin: 2.0, end: _animationValue),
-      curve: Curves.easeInOut,
-      onEnd: () {
-        if (widget.animateBorder) {
-          setState(() {
-            _animationValue = _animationValue == 8.0 ? 2.0 : 8.0;
-          });
-        }
-      },
-      builder: (_, double value, __) {
-        return Container(
-          decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.primary,
-            border: widget.showBorder
-                ? Border.all(
-                    width: 1.0,
-                    color: AppColors.errorColor,
-                  )
-                : null,
-            boxShadow: widget.showBorder && widget.animateBorder
-                ? [
-                    BoxShadow(
-                        color: AppColors.errorColor.withOpacity(0.35),
-                        blurRadius: value,
-                        spreadRadius: value)
-                  ]
-                : null,
-            borderRadius: const BorderRadius.all(
-              Radius.circular(8.0),
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.primary,
+        border: showBorder
+            ? Border.all(
+                width: 1.0,
+                color: AppColors.errorColor,
+              )
+            : null,
+        borderRadius: const BorderRadius.all(
+          Radius.circular(8.0),
+        ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(15.0, 20.0, 15.0, 20.0),
+        child: Row(
+          children: [
+            const Icon(
+              Icons.info,
+              size: 20.0,
+              color: Colors.white,
             ),
-          ),
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(15.0, 20.0, 15.0, 20.0),
-            child: Row(
-              children: [
-                const Icon(
-                  Icons.info,
-                  size: 20.0,
-                  color: Colors.white,
-                ),
-                const SizedBox(
-                  width: 15.0,
-                ),
-                Expanded(
-                  child: widget.isSelectable
-                      ? SelectableText(widget.text,
-                          style: const TextStyle(fontSize: 14.0))
-                      : Text(widget.text,
-                          style: const TextStyle(fontSize: 14.0)),
-                ),
-              ],
+            const SizedBox(
+              width: 15.0,
             ),
-          ),
-        );
-      },
+            Expanded(
+              child: isSelectable
+                  ? SelectableText(text, style: const TextStyle(fontSize: 14.0))
+                  : Text(text, style: const TextStyle(fontSize: 14.0)),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
This PR removes the static P2P swap warning banner and adds a warning modal. The modal is presented to the user when they are starting/joining a swap for the first time. Once the user presses continue on the modal, the modal will not be shown anymore.

![image](https://github.com/hypercore-one/syrius/assets/90819192/5eaee48e-90fe-4b95-bb10-db2212e74d03)
