### PR TITLE
Refactor expiration warnings and increase counter HTLC duration

### DIFF
--- a/lib/handlers/htlc_swaps_handler.dart
+++ b/lib/handlers/htlc_swaps_handler.dart
@@ -9,9 +9,7 @@ import 'package:zenon_syrius_wallet_flutter/main.dart';
 import 'package:zenon_syrius_wallet_flutter/model/block_data.dart';
 import 'package:zenon_syrius_wallet_flutter/model/p2p_swap/htlc_swap.dart';
 import 'package:zenon_syrius_wallet_flutter/model/p2p_swap/p2p_swap.dart';
-import 'package:zenon_syrius_wallet_flutter/utils/account_block_utils.dart';
-import 'package:zenon_syrius_wallet_flutter/utils/date_time_utils.dart';
-import 'package:zenon_syrius_wallet_flutter/utils/format_utils.dart';
+import 'package:zenon_syrius_wallet_flutter/utils/utils.dart';
 import 'package:znn_sdk_dart/znn_sdk_dart.dart';
 
 class HtlcSwapsHandler {
@@ -261,7 +259,9 @@ class HtlcSwapsHandler {
     for (final swap in swaps) {
       if (swap.initialHtlcExpirationTime < now ||
           (swap.counterHtlcExpirationTime != null &&
-              swap.counterHtlcExpirationTime! < now)) {
+              swap.counterHtlcExpirationTime! -
+                      kMinSafeTimeToCompleteSwap.inSeconds <
+                  now)) {
         swap.state = P2pSwapState.reclaimable;
         await htlcSwapsService!.storeSwap(swap);
       }

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -220,8 +220,7 @@ const List<Tabs> kTabsWithTextTitles = [
 
 // P2P swap constants
 const Duration kInitialHtlcDuration = Duration(hours: 8);
-const Duration kCounterHtlcDuration = Duration(minutes: 30);
+const Duration kCounterHtlcDuration = Duration(hours: 1);
 const Duration kMaxAllowedInitialHtlcDuration = Duration(hours: 24);
-const Duration kMinSafeTimeToFindPreimage = Duration(hours: 7);
+const Duration kMinSafeTimeToFindPreimage = Duration(hours: 6);
 const Duration kMinSafeTimeToCompleteSwap = Duration(minutes: 10);
-const Duration kHtlcExpirationWarningThreshold = Duration(minutes: 20);

--- a/lib/widgets/modular_widgets/p2p_swap_widgets/htlc_card.dart
+++ b/lib/widgets/modular_widgets/p2p_swap_widgets/htlc_card.dart
@@ -149,17 +149,10 @@ class _HtlcCardState extends State<HtlcCard>
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                widget.title,
-                style: const TextStyle(
-                    fontSize: 14.0, color: AppColors.subtitleColor),
-              ),
-              _getExpirationWarning(widget.expirationTime!),
-            ],
+          Text(
+            widget.title,
+            style:
+                const TextStyle(fontSize: 14.0, color: AppColors.subtitleColor),
           ),
           const SizedBox(
             height: 10,
@@ -192,42 +185,6 @@ class _HtlcCardState extends State<HtlcCard>
             ],
           ),
           _getDetailsSection(),
-        ],
-      ),
-    );
-  }
-
-  Widget _getExpirationWarning(int expirationTime) {
-    final remaining =
-        Duration(seconds: expirationTime - DateTimeUtils.unixTimeNow);
-    return Visibility(
-      visible:
-          !remaining.isNegative && remaining < kHtlcExpirationWarningThreshold,
-      child: Row(
-        children: [
-          const Icon(
-            Icons.error_outline_rounded,
-            color: AppColors.errorColor,
-            size: 16.0,
-          ),
-          const SizedBox(
-            width: 5.0,
-          ),
-          TweenAnimationBuilder<Duration>(
-            duration: remaining,
-            tween: Tween(begin: remaining, end: Duration.zero),
-            onEnd: () => setState(() {}),
-            builder: (_, Duration d, __) {
-              return Text(
-                'Expires in ${d.toString().split('.').first}',
-                style: const TextStyle(
-                  fontSize: 12.0,
-                  color: AppColors.errorColor,
-                  height: 1,
-                ),
-              );
-            },
-          ),
         ],
       ),
     );

--- a/lib/widgets/modular_widgets/p2p_swap_widgets/modals/join_native_swap_modal.dart
+++ b/lib/widgets/modular_widgets/p2p_swap_widgets/modals/join_native_swap_modal.dart
@@ -318,7 +318,7 @@ class _JoinNativeSwapModalState extends State<JoinNativeSwapModal> {
                   'The counterparty will have ',
                   children: [
                     TextSpan(
-                        text: '${(kCounterHtlcDuration).inMinutes} minutes',
+                        text: '~${(kCounterHtlcDuration).inHours} hour',
                         style: const TextStyle(
                             fontSize: 14.0, color: Colors.white)),
                     BulletPointCard.textSpan(' to complete the swap.'),

--- a/lib/widgets/modular_widgets/p2p_swap_widgets/modals/native_p2p_swap_modal.dart
+++ b/lib/widgets/modular_widgets/p2p_swap_widgets/modals/native_p2p_swap_modal.dart
@@ -100,19 +100,21 @@ class _NativeP2pSwapModalState extends State<NativeP2pSwapModal> {
   }
 
   Widget _getPendingView() {
-    return SizedBox(
+    return const SizedBox(
       height: 215.0,
-      child:
-          Column(mainAxisAlignment: MainAxisAlignment.center, children: const [
-        Text(
-          'Starting swap. This will take a moment.',
-          style: TextStyle(
-            fontSize: 16.0,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            'Starting swap. This will take a moment.',
+            style: TextStyle(
+              fontSize: 16.0,
+            ),
           ),
-        ),
-        SizedBox(height: 25.0),
-        SyriusLoadingWidget()
-      ]),
+          SizedBox(height: 25.0),
+          SyriusLoadingWidget()
+        ],
+      ),
     );
   }
 
@@ -410,6 +412,7 @@ class _NativeP2pSwapModalState extends State<NativeP2pSwapModal> {
                     ),
                   ),
                 ),
+                _getExpirationWarningForOutgoingSwap(swap),
                 _getSwapButtonViewModel(swap),
                 const SizedBox(
                   height: 25,
@@ -433,6 +436,30 @@ class _NativeP2pSwapModalState extends State<NativeP2pSwapModal> {
         ],
       );
     }
+  }
+
+  Widget _getExpirationWarningForOutgoingSwap(HtlcSwap swap) {
+    const warningThreshold = Duration(minutes: 10);
+    final timeToCompleteSwap = Duration(
+            seconds:
+                swap.counterHtlcExpirationTime! - DateTimeUtils.unixTimeNow) -
+        kMinSafeTimeToCompleteSwap;
+    return TweenAnimationBuilder<Duration>(
+      duration: timeToCompleteSwap,
+      tween: Tween(begin: timeToCompleteSwap, end: Duration.zero),
+      onEnd: () => setState(() {}),
+      builder: (_, Duration d, __) {
+        return Visibility(
+          visible: timeToCompleteSwap <= warningThreshold,
+          child: Padding(
+            padding: const EdgeInsets.only(bottom: 25.0),
+            child: ImportantTextContainer(
+              text: 'The swap will expire in ${d.toString().split('.').first}',
+            ),
+          ),
+        );
+      },
+    );
   }
 
   Widget _getSwapButtonViewModel(HtlcSwap swap) {


### PR DESCRIPTION
Based on tester feedback, the counter HTLC duration of a P2P swap has been increased to 1 hour, so that the user has a little more time to complete the swap. The changes to the P2P swap constants now guarantee that:

1. The starting party has ~50 minutes to execute the swap after the counterparty has joined the swap (`kCounterHtlcDuration` - `kMinSafeTimeToCompleteSwap`). 
2. The joining party has ~1 hour to join the swap after the swap has been started (`kInitialHtlcDuration` - `kCounterHtlcDuration` - `kMinSafeTimeToFindPreimage`).
3. The joining party has at least ~6 hours to find the preimage after the starting party has executed the swap (`kMinSafeTimeToFindPreimage`).

The expiration warnings from the `HtlcCard` widget have been removed and a new "swap expiration warning" has been added to the `NativeP2pSwapModal`. This warning takes the `kMinSafeTimeToCompleteSwap` into account when showing the remaining time to complete the swap, as opposed to the `HtlcCard`'s warning that only showed the actual expiration time of the HTLC, misguiding the user of the actual time left to complete the swap.

In addition, the swap is now marked as expired when the time until the counter HTLC expires is less than `kMinSafeTimeToCompleteSwap`.

The new swap expiration warning:
![expires](https://github.com/hypercore-one/syrius/assets/90819192/e30ff7f9-32fe-4cde-a9fe-77052a2dc235)
