### PR TITLE
Fix decimal extraction extension method

### DIFF
--- a/lib/utils/extensions.dart
+++ b/lib/utils/extensions.dart
@@ -10,6 +10,9 @@ extension StringExtensions on String {
 
   BigInt extractDecimals(int decimals) {
     if (!contains('.')) {
+      if (decimals == 0 && isEmpty) {
+        return BigInt.zero;
+      }
       return BigInt.parse(this + ''.padRight(decimals, '0'));
     }
     List<String> parts = split('.');
@@ -19,7 +22,6 @@ extension StringExtensions on String {
             ? parts[1].substring(0, decimals)
             : parts[1].padRight(decimals, '0')));
   }
-  //BigInt.parse(num.parse(this).toStringAsFixed(decimals).replaceAll('.', ''));
 
   String abs() => this;
 }


### PR DESCRIPTION
This `extractDecimals` extension method could not parse a string when the `decimals` parameter is zero, because the `BigInt.parse` method requires a non-empty input.